### PR TITLE
Updated linter-cspm to work with linter v.2.0.0

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -32,14 +32,14 @@ module.exports =
           when 'linux' then "/opt/fdr/bin/"
       title: "Path to directory containing fdr4"
       type: "string"
-  
+
   activate: ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-cspm.fdrInstallDirectory', @createShellCommand
-      
+
   deactivate: ->
     @subscriptions.dispose()
-  
+
   createShellCommand: =>
     fdrDir = atom.config.get 'linter-cspm.fdrInstallDirectory'
     executable = 'refines'+(if process.platform == 'win32' then ".exe" else '')
@@ -47,9 +47,10 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'CSPm'
       grammarScopes: ['source.cspm']
       scope: 'file'
-      lintOnFly: false
+      lintsOnChange: false
       lint: (textEditor) =>
         fdrDir = atom.config.get 'linter-cspm.fdrInstallDirectory'
         executable = 'refines'+(if process.platform == 'win32' then ".exe" else '')
@@ -69,40 +70,65 @@ module.exports =
               for line in lines
                 if line == ""
                   continue
+                console.log "Line:"+line
                 if currentMessage == null or line.indexOf("    ") != 0
                   # Start a new message
-                  if currentMessage and currentMessage.text.length > 0
+                  if currentMessage and currentMessage.excerpt.length > 0
                     messages.push currentMessage
-                    
-                  if line == "<unknown location>:"
+
+                  if line.startsWith("<unknown location>:")
                     currentMessage = {
-                      type: 'error',
-                      text: "",
-                      filePath: textEditor.getPath(),
+                      severity: 'error',
+                      excerpt: "",
+                      location: {
+                        file: textEditor.getPath(),
+                        position: [[0,0],[0,0]]
+                      }
                     }
                   else
-                    columnsStart = line.lastIndexOf(":", line.length-2)
+                    columnsStart = line.lastIndexOf(":", line.length)
+
+                    # If it is not multi-line, then the difference from EOL is greater
+                    if line.indexOf("    ") != 0
+                      columnsStart = line.lastIndexOf(":",columnsStart-1)
+
                     lineNumPos = line.lastIndexOf(":", columnsStart-1)
-                    columnsRange = splitRange(line.slice(columnsStart+1, line.length-1))
+                    columnsRange = splitRange(line.slice(columnsStart+1, line.length))
                     linesRange = splitRange(line.slice(lineNumPos+1, columnsStart))
                     currentMessage = {
-                      type: 'error',
-                      text: "",
-                      filePath: line.slice(0, lineNumPos),
+                      severity: 'error',
+                      excerpt: "",
+                      location: {
+                        file: line.slice(0, lineNumPos)
+                      }
                     }
                     if columnsRange and linesRange
                       [colStart, colEnd] = columnsRange
                       [lineStart, lineEnd] = linesRange
-                      currentMessage.range = new Range([lineStart-1, colStart-1], [lineEnd-1, colEnd-1])
-                else
-                  if currentMessage.text.length == 0
-                    currentMessage.text += line.slice(4)+"\n"
+                      currentMessage.location.position = new Range([lineStart-1, colStart-1], [lineEnd-1, colEnd-1])
 
-              if currentMessage and currentMessage.text.length > 0
+                  console.log "Message:"+currentMessage
+                  console.log "Position:"+columnsRange+" - "+linesRange
+
+                if line.indexOf("    ") != 0
+                  currentMessage.excerpt = line.slice(line.lastIndexOf(":", line.length)+1)
+
+                else
+                  if currentMessage.excerpt.length == 0
+                    currentMessage.excerpt += line.slice(4)+"\n"
+                  else
+                    if currentMessage.description
+                      currentMessage.description += "\r"+line
+                    else
+                      currentMessage.description = line
+
+                console.log "In Promise:"+currentMessage
+                console.log "Message text:"+currentMessage.excerpt
+              if currentMessage and currentMessage.excerpt.length > 0
                 messages.push currentMessage
 
               console.log messages
-              resolve messages 
+              resolve messages
 
           process.onWillThrowError ({error,handle}) ->
             atom.notifications.addError "Failed to run #{@executablePath}",

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -22,6 +22,63 @@ getRootCSPFile = (fileName) ->
   else
     return fileName
 
+definedString = (string) ->
+   definedAt = string.indexOf(".csp")
+   if definedAt >= 0
+     console.log "Some .cps link"
+     # there is some .csp file, replace it by an actual link!
+     match = /:\d+:\d+-\d+:\d+/.exec(string)
+     if match != null
+       pathEnding = string.lastIndexOf(match)
+       pathStart = string.lastIndexOf(" ",pathEnding)
+       lineInfo = match[0].split(":")
+       lineNo = lineInfo[1]
+       colNo = lineInfo[2].split("-")[0]
+       console.log "lineNo: " +lineNo + " col:" + colNo
+       if pathEnding >=0 and pathStart >= 0
+         pathurl = string.slice(pathStart+1,pathEnding)
+         return "* "+string.slice(0,pathStart)+" ["+string.slice(pathStart+1,string.length-1)+"](atom://core/open/file?filename="+pathurl+"&line="+lineNo+"&column="+colNo+") "
+       else
+         return string
+     else
+       match = /:\d+:\d+-\d+/.exec(string)
+       if match != null
+         pathEnding = string.lastIndexOf(match)
+         pathStart = string.lastIndexOf(" ",pathEnding)
+         lineInfo = match[0].split(":")
+         lineNo = lineInfo[1]
+         colNo = lineInfo[2].split("-")[0]
+         console.log "lineNo: " +lineNo + " col:" + colNo
+         if pathEnding >=0 and pathStart >= 0
+           pathurl = string.slice(pathStart+1,pathEnding)
+
+           return "* "+string.slice(0,pathStart)+" ["+string.slice(pathStart+1,string.length-1)+"](atom://core/open/file?filename="+pathurl+"&line="+lineNo+"&column="+colNo+") "
+         else
+           return string
+   else
+     console.log "No .csp"
+     return string
+#  definedAt = string.indexOf("defined at")
+#  if definedAt >= 0
+#    definedAt = definedAt+10
+#    match = string.exec(/:\d+:\d+-\d+:\d+)/)
+#    if match != null
+#      lineNumber = match.split(':')[0]
+#      pathPos = string.lastIndexOf(match)
+#      path = string.slice(definedAt,pathPos-1)
+#      return string.slice(0,definedAt)+"["+string.slice(definedAt+1,string.length-1)"]("+path+"))"
+#    else
+#      match = string.exec(/:\d+:\d+-\d+)/)
+#    if match != null
+#        lineNumber = match.split(':')[0]
+#          pathPos = string.lastIndexOf(match)
+#          path = string.slice(definedAt,pathPos-1)
+#          return string.slice(0,definedAt)+"["+string.slice(definedAt+1,string.length-1)"]("+path+"))"
+#      else
+#        return string
+#  else
+#    return string
+
 module.exports =
   config:
     fdrInstallDirectory:
@@ -118,9 +175,9 @@ module.exports =
                     currentMessage.excerpt += line.slice(4)+"\n"
                   else
                     if currentMessage.description
-                      currentMessage.description += "\r"+line
+                      currentMessage.description += "\r"+definedString line
                     else
-                      currentMessage.description = line
+                      currentMessage.description = definedString line
 
                 console.log "In Promise:"+currentMessage
                 console.log "Message text:"+currentMessage.excerpt

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -40,7 +40,6 @@ minimizeStr = (string1,string2) ->
 definedString = (textEditor,string) ->
    definedAt = string.indexOf(".csp")
    if definedAt >= 0
-     #console.log "Some .cps link"
      # there is some .csp file, replace it by an actual link!
      match = /:\d+:\d+-\d+:\d+/.exec(string)
      if match != null
@@ -49,7 +48,7 @@ definedString = (textEditor,string) ->
        lineInfo = match[0].split(":")
        lineNo = lineInfo[1]
        colNo = lineInfo[2].split("-")[0]
-       #console.log "lineNo: " +lineNo + " col:" + colNo
+
        if pathEnding >=0 and pathStart >= 0
          pathurl = string.slice(pathStart+1,pathEnding)
          # Because displayPath may be rather long, we attempt to shorten it using
@@ -57,7 +56,6 @@ definedString = (textEditor,string) ->
          filePath = textEditor.getPath()
          displayPath = string.slice(pathStart+1,pathEnding+match[0].length)
          remaining = string.slice(pathEnding+match[0].length,string.length)
-         #console.log "curr path: " + filePath + "so: " + minimizeStr(displayPath,filePath)
          return "* "+string.slice(0,pathStart)+" ["+minimizeStr(displayPath,filePath)+"](atom://core/open/file?filename="+pathurl+"&line="+lineNo+"&column="+colNo+")"+remaining
        else
          return string
@@ -72,39 +70,15 @@ definedString = (textEditor,string) ->
 
          filePath = getRootCSPFile(textEditor.getPath())
 
-         #console.log "lineNo: " +lineNo + " col:" + colNo
          if pathEnding >=0 and pathStart >= 0
            pathurl = string.slice(pathStart+1,pathEnding)
            displayPath = string.slice(pathStart+1,pathEnding+match[0].length)
            remaining = string.slice(pathEnding+match[0].length,string.length)
-           #console.log "match.length:" + match[0].length + "remaining"+remaining
-           #console.log "curr path: " + filePath + " displaypath: " + displayPath + "so: " + minimizeStr(displayPath,filePath)
            return "* "+string.slice(0,pathStart)+" ["+minimizeStr(displayPath,filePath)+"](atom://core/open/file?filename="+pathurl+"&line="+lineNo+"&column="+colNo+")"+remaining
          else
            return string
    else
-     #console.log "No .csp"
      return string
-#  definedAt = string.indexOf("defined at")
-#  if definedAt >= 0
-#    definedAt = definedAt+10
-#    match = string.exec(/:\d+:\d+-\d+:\d+)/)
-#    if match != null
-#      lineNumber = match.split(':')[0]
-#      pathPos = string.lastIndexOf(match)
-#      path = string.slice(definedAt,pathPos-1)
-#      return string.slice(0,definedAt)+"["+string.slice(definedAt+1,string.length-1)"]("+path+"))"
-#    else
-#      match = string.exec(/:\d+:\d+-\d+)/)
-#    if match != null
-#        lineNumber = match.split(':')[0]
-#          pathPos = string.lastIndexOf(match)
-#          path = string.slice(definedAt,pathPos-1)
-#          return string.slice(0,definedAt)+"["+string.slice(definedAt+1,string.length-1)"]("+path+"))"
-#      else
-#        return string
-#  else
-#    return string
 
 module.exports =
   config:
@@ -154,7 +128,7 @@ module.exports =
               for line in lines
                 if line == ""
                   continue
-                console.log "Line:"+line
+
                 if currentMessage == null or line.indexOf("    ") != 0
                   # Start a new message
                   if currentMessage and currentMessage.excerpt.length > 0
@@ -191,9 +165,6 @@ module.exports =
                       [lineStart, lineEnd] = linesRange
                       currentMessage.location.position = new Range([lineStart-1, colStart-1], [lineEnd-1, colEnd-1])
 
-                  console.log "Message:"+currentMessage
-                  console.log "Position:"+columnsRange+" - "+linesRange
-
                 if line.indexOf("    ") != 0
                   currentMessage.excerpt = line.slice(line.lastIndexOf(":", line.length)+1)
 
@@ -206,12 +177,9 @@ module.exports =
                     else
                       currentMessage.description = definedString(textEditor,line)
 
-                console.log "In Promise:"+currentMessage
-                console.log "Message text:"+currentMessage.excerpt
               if currentMessage and currentMessage.excerpt.length > 0
                 messages.push currentMessage
 
-              console.log messages
               resolve messages
 
           process.onWillThrowError ({error,handle}) ->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   }


### PR DESCRIPTION
Dear Tom,

This is a pull request containing changes to make linter-cspm work with Atom's linter version 2.0.0.

I've also added support for parsing other error messages generated by FDR, inserting clickable links on messages containing .csp file paths. Screenshot with example below:

![Screenshot from 2020-03-28 01-00-29](https://user-images.githubusercontent.com/5167368/77909033-802e7800-7284-11ea-8c93-5d978375f0fa.png)

I'm not a coffee script expert, but I hope the patch is useful :-)

Pedro